### PR TITLE
Update Forge protocol

### DIFF
--- a/src/main/java/org/lanternpowered/server/catalog/VirtualCatalogType.java
+++ b/src/main/java/org/lanternpowered/server/catalog/VirtualCatalogType.java
@@ -23,29 +23,10 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.lanternpowered.server.network.vanilla.message.type.play;
+package org.lanternpowered.server.catalog;
 
-import org.lanternpowered.server.network.message.Message;
-import org.spongepowered.api.item.inventory.ItemStack;
+import org.spongepowered.api.CatalogType;
 
-import javax.annotation.Nullable;
+public interface VirtualCatalogType extends CatalogType {
 
-public final class MessagePlayInCreativeWindowAction implements Message {
-
-    private final int slot;
-    @Nullable private final ItemStack itemStack;
-
-    public MessagePlayInCreativeWindowAction(int slot, @Nullable ItemStack itemStack) {
-        this.itemStack = itemStack;
-        this.slot = slot;
-    }
-
-    public int getSlot() {
-        return this.slot;
-    }
-
-    @Nullable
-    public ItemStack getItemStack() {
-        return this.itemStack;
-    }
 }

--- a/src/main/java/org/lanternpowered/server/config/GlobalConfig.java
+++ b/src/main/java/org/lanternpowered/server/config/GlobalConfig.java
@@ -130,7 +130,7 @@ public class GlobalConfig extends ConfigBase implements ChunkLoadingConfig {
     }
 
     @ConfigSerializable
-    private static final class Server {
+    public static final class Server {
 
         @Setting(value = "ip", comment =
                 "The ip address that should be bound, leave it empty\n " +
@@ -202,6 +202,24 @@ public class GlobalConfig extends ConfigBase implements ChunkLoadingConfig {
         @Setting(value = "prevent-proxy-connections", comment = "Whether proxy connections should be prevented.\n"
                 + "This is only supported in the online mode.")
         private boolean preventProxyConnections = false;
+
+        @Setting(value = "forge", comment = "Settings related to forge protocol or forge related features.")
+        private Forge forge = new Forge();
+
+        @ConfigSerializable
+        public static final class Forge {
+
+            @Setting(value = "enabled", comment = "Whether the forge protocol should be enabled,"
+                    + "\ndisabling this won't block forge users from joining."
+                    + "\nAdvantages:"
+                    + "\n - Hides modded items in the creative menu"
+                    + "\n - ...")
+            private boolean enabled = true;
+
+            public boolean isEnabled() {
+                return this.enabled;
+            }
+        }
     }
 
     @ConfigSerializable
@@ -298,6 +316,10 @@ public class GlobalConfig extends ConfigBase implements ChunkLoadingConfig {
 
     public void setViewDistance(int viewDistance) {
         this.worlds.viewDistance = GenericMath.clamp(viewDistance, MIN_VIEW_DISTANCE, MAX_VIEW_DISTANCE);
+    }
+
+    public Server.Forge getForge() {
+        return this.server.forge;
     }
 
     public Chat getChat() {

--- a/src/main/java/org/lanternpowered/server/data/io/store/item/ItemStackStore.java
+++ b/src/main/java/org/lanternpowered/server/data/io/store/item/ItemStackStore.java
@@ -110,7 +110,6 @@ public final class ItemStackStore extends DataHolderStore<LanternItemStack> impl
                 new DataValueItemTypeObjectSerializer<>(Keys.TREE_TYPE, TreeTypeRegistryModule.get());
         add(BlockTypes.LOG, treeTypeSerializer);
         add(BlockTypes.WOODEN_SLAB, treeTypeSerializer);
-        add(BlockTypes.DOUBLE_WOODEN_SLAB, treeTypeSerializer);
         add(BlockTypes.PLANKS, treeTypeSerializer);
         add(BlockTypes.LEAVES, treeTypeSerializer);
         add(BlockTypes.SAPLING, treeTypeSerializer);
@@ -122,12 +121,10 @@ public final class ItemStackStore extends DataHolderStore<LanternItemStack> impl
         final DataValueItemTypeObjectSerializer<SlabType> stoneSlab1Serializer =
                 new DataValueItemTypeObjectSerializer<>(Keys.SLAB_TYPE, SlabTypeRegistryModule.get());
         add(BlockTypes.STONE_SLAB, stoneSlab1Serializer);
-        add(BlockTypes.DOUBLE_STONE_SLAB, stoneSlab1Serializer);
         final DataValueItemTypeObjectSerializer<SlabType> stoneSlab2Serializer =
                 new DataValueItemTypeObjectSerializer<>(Keys.SLAB_TYPE, SlabTypeRegistryModule.get(),
                         dataValue -> dataValue + 8, internalId -> internalId - 8);
         add(BlockTypes.STONE_SLAB2, stoneSlab2Serializer);
-        add(BlockTypes.DOUBLE_STONE_SLAB2, stoneSlab2Serializer);
         add(BlockTypes.QUARTZ_BLOCK, new QuartzItemTypeSerializer());
         final DataValueItemTypeObjectSerializer<SandstoneType> sandstoneTypeSerializer =
                 new DataValueItemTypeObjectSerializer<>(Keys.SANDSTONE_TYPE, SandstoneTypeRegistryModule.get());

--- a/src/main/java/org/lanternpowered/server/effect/sound/LanternSoundType.java
+++ b/src/main/java/org/lanternpowered/server/effect/sound/LanternSoundType.java
@@ -25,28 +25,40 @@
  */
 package org.lanternpowered.server.effect.sound;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.flowpowered.math.vector.Vector3d;
 import org.lanternpowered.server.catalog.PluginCatalogType;
+import org.lanternpowered.server.catalog.VirtualCatalogType;
 import org.lanternpowered.server.network.vanilla.message.type.play.MessagePlayOutNamedSoundEffect;
 import org.lanternpowered.server.network.vanilla.message.type.play.MessagePlayOutSoundEffect;
 import org.lanternpowered.server.network.vanilla.message.type.play.MessagePlayOutSoundEffectBase;
 import org.spongepowered.api.effect.sound.SoundCategory;
 import org.spongepowered.api.effect.sound.SoundType;
 
-public final class LanternSoundType extends PluginCatalogType.Base implements SoundType {
+public class LanternSoundType extends PluginCatalogType.Base implements SoundType {
 
     private final int eventId;
 
     public LanternSoundType(String pluginId, String id, String name, int eventId) {
         super(pluginId, id, name);
+        checkArgument(eventId >= 0);
         this.eventId = eventId;
     }
 
-    public LanternSoundType(String pluginId, String id, String name) {
+    private LanternSoundType(String pluginId, String id, String name) {
         super(pluginId, id, name);
         this.eventId = -1;
+    }
+
+    /**
+     * Gets the event id. Returns {@code -1} when virtual (file name based).
+     *
+     * @return The event id
+     */
+    public int getEventId() {
+        return this.eventId;
     }
 
     public MessagePlayOutSoundEffectBase createMessage(Vector3d position, SoundCategory soundCategory,
@@ -57,6 +69,13 @@ public final class LanternSoundType extends PluginCatalogType.Base implements So
             return new MessagePlayOutSoundEffect(this.eventId, position, soundCategory, volume, pitch);
         } else {
             return new MessagePlayOutNamedSoundEffect(getName(), position, soundCategory, volume, pitch);
+        }
+    }
+
+    static class Virtual extends LanternSoundType implements VirtualCatalogType {
+
+        Virtual(String pluginId, String id, String name) {
+            super(pluginId, id, name);
         }
     }
 }

--- a/src/main/java/org/lanternpowered/server/effect/sound/LanternSoundTypeBuilder.java
+++ b/src/main/java/org/lanternpowered/server/effect/sound/LanternSoundTypeBuilder.java
@@ -42,6 +42,6 @@ public final class LanternSoundTypeBuilder implements SoundType.Builder {
 
     @Override
     public SoundType build(String id) {
-        return new LanternSoundType(InternalPluginsInfo.SpongePlatform.IDENTIFIER, id, id);
+        return new LanternSoundType.Virtual(InternalPluginsInfo.SpongePlatform.IDENTIFIER, id, id);
     }
 }

--- a/src/main/java/org/lanternpowered/server/game/LanternGameRegistry.java
+++ b/src/main/java/org/lanternpowered/server/game/LanternGameRegistry.java
@@ -733,6 +733,10 @@ public class LanternGameRegistry implements GameRegistry {
         return this;
     }
 
+    public Collection<CatalogRegistryModule<?>> getCatalogRegistryModules() {
+        return Collections.unmodifiableCollection(this.catalogRegistryMap.values());
+    }
+
     /**
      * Gets the {@link RegistryModule} for the specified class type.
      *

--- a/src/main/java/org/lanternpowered/server/game/registry/InternalPluginCatalogRegistryModule.java
+++ b/src/main/java/org/lanternpowered/server/game/registry/InternalPluginCatalogRegistryModule.java
@@ -30,7 +30,10 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.objects.Object2IntMap;
+import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import org.lanternpowered.server.catalog.InternalCatalogType;
+import org.lanternpowered.server.catalog.VirtualCatalogType;
 import org.spongepowered.api.CatalogType;
 
 import java.util.Optional;
@@ -76,5 +79,19 @@ public class InternalPluginCatalogRegistryModule<T extends CatalogType> extends 
     @Override
     public Optional<T> getByInternalId(int internalId) {
         return Optional.ofNullable(this.byInternalId.get(internalId));
+    }
+
+    protected Int2ObjectMap<T> getInternalIdMappings() {
+        return this.byInternalId;
+    }
+
+    protected Object2IntMap<String> getRegistryDataMappings() {
+        final Object2IntMap<String> mappings = new Object2IntOpenHashMap<>();
+        this.byInternalId.int2ObjectEntrySet().forEach(entry -> {
+            if (!(entry.getValue() instanceof VirtualCatalogType)) {
+                mappings.put(entry.getValue().getId(), entry.getIntKey());
+            }
+        });
+        return mappings;
     }
 }

--- a/src/main/java/org/lanternpowered/server/game/registry/forge/ForgeCatalogRegistryModule.java
+++ b/src/main/java/org/lanternpowered/server/game/registry/forge/ForgeCatalogRegistryModule.java
@@ -23,29 +23,17 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.lanternpowered.server.network.vanilla.message.type.play;
+package org.lanternpowered.server.game.registry.forge;
 
-import org.lanternpowered.server.network.message.Message;
-import org.spongepowered.api.item.inventory.ItemStack;
+import org.spongepowered.api.CatalogType;
+import org.spongepowered.api.registry.CatalogRegistryModule;
 
-import javax.annotation.Nullable;
+public interface ForgeCatalogRegistryModule<T extends CatalogType> extends CatalogRegistryModule<T> {
 
-public final class MessagePlayInCreativeWindowAction implements Message {
-
-    private final int slot;
-    @Nullable private final ItemStack itemStack;
-
-    public MessagePlayInCreativeWindowAction(int slot, @Nullable ItemStack itemStack) {
-        this.itemStack = itemStack;
-        this.slot = slot;
-    }
-
-    public int getSlot() {
-        return this.slot;
-    }
-
-    @Nullable
-    public ItemStack getItemStack() {
-        return this.itemStack;
-    }
+    /**
+     * Gets the {@link ForgeRegistryData} for this registry.
+     *
+     * @return The forge registry data
+     */
+    ForgeRegistryData getRegistryData();
 }

--- a/src/main/java/org/lanternpowered/server/game/registry/forge/ForgeRegistryData.java
+++ b/src/main/java/org/lanternpowered/server/game/registry/forge/ForgeRegistryData.java
@@ -23,29 +23,41 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.lanternpowered.server.network.vanilla.message.type.play;
+package org.lanternpowered.server.game.registry.forge;
 
-import org.lanternpowered.server.network.message.Message;
-import org.spongepowered.api.item.inventory.ItemStack;
+import it.unimi.dsi.fastutil.objects.Object2IntMap;
 
-import javax.annotation.Nullable;
+public final class ForgeRegistryData {
 
-public final class MessagePlayInCreativeWindowAction implements Message {
+    private final String moduleId;
+    private final Object2IntMap<String> mappings;
 
-    private final int slot;
-    @Nullable private final ItemStack itemStack;
-
-    public MessagePlayInCreativeWindowAction(int slot, @Nullable ItemStack itemStack) {
-        this.itemStack = itemStack;
-        this.slot = slot;
+    /**
+     * Constructs a new {@link ForgeRegistryData} object.
+     *
+     * @param moduleId The module id
+     * @param mappings The mappings
+     */
+    public ForgeRegistryData(String moduleId, Object2IntMap<String> mappings) {
+        this.moduleId = moduleId;
+        this.mappings = mappings;
     }
 
-    public int getSlot() {
-        return this.slot;
+    /**
+     * Gets the module id.
+     *
+     * @return The module id
+     */
+    public String getModuleId() {
+        return this.moduleId;
     }
 
-    @Nullable
-    public ItemStack getItemStack() {
-        return this.itemStack;
+    /**
+     * Gets the mappings.
+     *
+     * @return The mappings
+     */
+    public Object2IntMap<String> getMappings() {
+        return this.mappings;
     }
 }

--- a/src/main/java/org/lanternpowered/server/game/registry/type/block/BlockRegistryModule.java
+++ b/src/main/java/org/lanternpowered/server/game/registry/type/block/BlockRegistryModule.java
@@ -40,6 +40,8 @@ import static org.lanternpowered.server.text.translation.TranslationHelper.tr;
 
 import it.unimi.dsi.fastutil.bytes.Byte2ObjectMap;
 import it.unimi.dsi.fastutil.bytes.Byte2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.objects.Object2IntMap;
+import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import it.unimi.dsi.fastutil.objects.Object2ShortMap;
 import it.unimi.dsi.fastutil.objects.Object2ShortOpenHashMap;
 import it.unimi.dsi.fastutil.shorts.Short2ObjectMap;
@@ -75,6 +77,7 @@ import org.lanternpowered.server.block.trait.LanternBooleanTraits;
 import org.lanternpowered.server.block.trait.LanternEnumTraits;
 import org.lanternpowered.server.block.trait.LanternIntegerTraits;
 import org.lanternpowered.server.block.translation.SpongeTranslationProvider;
+import org.lanternpowered.server.catalog.VirtualCatalogType;
 import org.lanternpowered.server.data.key.LanternKeys;
 import org.lanternpowered.server.data.type.LanternBedPart;
 import org.lanternpowered.server.data.type.LanternDirtType;
@@ -91,6 +94,8 @@ import org.lanternpowered.server.data.type.LanternStoneType;
 import org.lanternpowered.server.data.type.LanternTreeType;
 import org.lanternpowered.server.game.Lantern;
 import org.lanternpowered.server.game.registry.AdditionalPluginCatalogRegistryModule;
+import org.lanternpowered.server.game.registry.forge.ForgeCatalogRegistryModule;
+import org.lanternpowered.server.game.registry.forge.ForgeRegistryData;
 import org.lanternpowered.server.game.registry.type.data.InstrumentTypeRegistryModule;
 import org.lanternpowered.server.game.registry.type.data.KeyRegistryModule;
 import org.lanternpowered.server.game.registry.type.item.ItemRegistryModule;
@@ -118,7 +123,8 @@ import java.util.function.Supplier;
         InstrumentTypeRegistryModule.class,
         BlockSoundGroupRegistryModule.class,
 })
-public final class BlockRegistryModule extends AdditionalPluginCatalogRegistryModule<BlockType> implements BlockRegistry {
+public final class BlockRegistryModule extends AdditionalPluginCatalogRegistryModule<BlockType> implements BlockRegistry,
+        ForgeCatalogRegistryModule<BlockType> {
 
     private static final BlockRegistryModule INSTANCE = new BlockRegistryModule();
 
@@ -142,6 +148,17 @@ public final class BlockRegistryModule extends AdditionalPluginCatalogRegistryMo
     @Override
     public int getBlockStatesCount() {
         return this.blockStateByPackedType.size();
+    }
+
+    @Override
+    public ForgeRegistryData getRegistryData() {
+        final Object2IntMap<String> map = new Object2IntOpenHashMap<>();
+        this.blockTypeByInternalId.short2ObjectEntrySet().forEach(entry -> {
+            if (!(entry.getValue() instanceof VirtualCatalogType)) {
+                map.put(entry.getValue().getId(), entry.getShortKey());
+            }
+        });
+        return new ForgeRegistryData("minecraft:blocks", map);
     }
 
     private void register0(int internalId, LanternBlockType blockType, BlockState2DataFunction stateToDataConverter) {
@@ -1066,11 +1083,6 @@ public final class BlockRegistryModule extends AdditionalPluginCatalogRegistryMo
                                 .withTrait(LanternEnumTraits.TREE_TYPE, LanternTreeType.OAK).get())
                         .translation(TranslationProvider.of(LanternEnumTraits.TREE_TYPE, type ->
                                 tr("tile.woodSlab." + type.getTranslationKeyBase() + ".name")))
-                        .itemType(builder -> builder
-                                .keysProvider(collection -> collection
-                                        .register(Keys.TREE_TYPE, LanternTreeType.OAK)
-                                )
-                        )
                         .properties(builder -> builder
                                 .add(hardness(2.0))
                                 .add(blastResistance(5.0)))
@@ -1727,11 +1739,6 @@ public final class BlockRegistryModule extends AdditionalPluginCatalogRegistryMo
                         .withTrait(enumTrait, defaultValue).get()
                         .withTrait(LanternBooleanTraits.SEAMLESS, false).get())
                 .translation(TranslationProvider.of(enumTrait))
-                .itemType(builder -> builder
-                        .keysProvider(collection -> collection
-                                .register(Keys.SLAB_TYPE, defaultValue)
-                        )
-                )
                 .properties(builder -> builder
                         .add(hardness(2.0))
                         .add(blastResistance(10.0)));

--- a/src/main/java/org/lanternpowered/server/game/registry/type/data/ProfessionRegistryModule.java
+++ b/src/main/java/org/lanternpowered/server/game/registry/type/data/ProfessionRegistryModule.java
@@ -25,12 +25,15 @@
  */
 package org.lanternpowered.server.game.registry.type.data;
 
+import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import org.lanternpowered.server.data.type.LanternProfession;
-import org.lanternpowered.server.game.registry.PluginCatalogRegistryModule;
+import org.lanternpowered.server.game.registry.InternalPluginCatalogRegistryModule;
+import org.lanternpowered.server.game.registry.forge.ForgeCatalogRegistryModule;
+import org.lanternpowered.server.game.registry.forge.ForgeRegistryData;
 import org.spongepowered.api.data.type.Profession;
 import org.spongepowered.api.data.type.Professions;
 
-public class ProfessionRegistryModule extends PluginCatalogRegistryModule<Profession> {
+public class ProfessionRegistryModule extends InternalPluginCatalogRegistryModule<Profession> implements ForgeCatalogRegistryModule<Profession> {
 
     public ProfessionRegistryModule() {
         super(Professions.class);
@@ -44,5 +47,13 @@ public class ProfessionRegistryModule extends PluginCatalogRegistryModule<Profes
         register(new LanternProfession("minecraft", "blacksmith", 3));
         register(new LanternProfession("minecraft", "butcher", 4));
         register(new LanternProfession("minecraft", "nitwit", 5));
+    }
+
+    @Override
+    public ForgeRegistryData getRegistryData() {
+        final Object2IntMap<String> mappings = getRegistryDataMappings();
+        // Forge uses a different profession id then in sponge, fix this mapping just for the client
+        mappings.put("minecraft:smith", mappings.remove("minecraft:blacksmith"));
+        return new ForgeRegistryData("minecraft:villagerprofessions", mappings);
     }
 }

--- a/src/main/java/org/lanternpowered/server/game/registry/type/effect/PotionEffectTypeRegistryModule.java
+++ b/src/main/java/org/lanternpowered/server/game/registry/type/effect/PotionEffectTypeRegistryModule.java
@@ -27,10 +27,13 @@ package org.lanternpowered.server.game.registry.type.effect;
 
 import org.lanternpowered.server.effect.potion.LanternPotionEffectType;
 import org.lanternpowered.server.game.registry.AdditionalInternalPluginCatalogRegistryModule;
+import org.lanternpowered.server.game.registry.forge.ForgeCatalogRegistryModule;
+import org.lanternpowered.server.game.registry.forge.ForgeRegistryData;
 import org.spongepowered.api.effect.potion.PotionEffectType;
 import org.spongepowered.api.effect.potion.PotionEffectTypes;
 
-public final class PotionEffectTypeRegistryModule extends AdditionalInternalPluginCatalogRegistryModule<PotionEffectType> {
+public final class PotionEffectTypeRegistryModule extends AdditionalInternalPluginCatalogRegistryModule<PotionEffectType>
+        implements ForgeCatalogRegistryModule<PotionEffectType> {
 
     public static PotionEffectTypeRegistryModule get() {
         return Holder.INSTANCE;
@@ -69,6 +72,11 @@ public final class PotionEffectTypeRegistryModule extends AdditionalInternalPlug
         register(new LanternPotionEffectType("minecraft", "levitation", 25, "levitation"));
         register(new LanternPotionEffectType("minecraft", "luck", 26, "luck"));
         register(new LanternPotionEffectType("minecraft", "unluck", 27, "unluck"));
+    }
+
+    @Override
+    public ForgeRegistryData getRegistryData() {
+        return new ForgeRegistryData("minecraft:potions", getRegistryDataMappings());
     }
 
     private static final class Holder {

--- a/src/main/java/org/lanternpowered/server/game/registry/type/effect/PotionTypeRegistryModule.java
+++ b/src/main/java/org/lanternpowered/server/game/registry/type/effect/PotionTypeRegistryModule.java
@@ -29,12 +29,14 @@ import org.lanternpowered.server.effect.potion.LanternPotionType;
 import org.lanternpowered.server.effect.potion.PotionType;
 import org.lanternpowered.server.effect.potion.PotionTypes;
 import org.lanternpowered.server.game.registry.InternalPluginCatalogRegistryModule;
+import org.lanternpowered.server.game.registry.forge.ForgeCatalogRegistryModule;
+import org.lanternpowered.server.game.registry.forge.ForgeRegistryData;
 import org.spongepowered.api.effect.potion.PotionEffect;
 import org.spongepowered.api.effect.potion.PotionEffectTypes;
 import org.spongepowered.api.registry.util.RegistrationDependency;
 
 @RegistrationDependency({ PotionEffectTypeRegistryModule.class })
-public class PotionTypeRegistryModule extends InternalPluginCatalogRegistryModule<PotionType> {
+public class PotionTypeRegistryModule extends InternalPluginCatalogRegistryModule<PotionType> implements ForgeCatalogRegistryModule<PotionType> {
 
     private static final PotionTypeRegistryModule INSTANCE = new PotionTypeRegistryModule();
 
@@ -117,5 +119,10 @@ public class PotionTypeRegistryModule extends InternalPluginCatalogRegistryModul
                 .add(PotionEffect.of(PotionEffectTypes.WEAKNESS, 0, 4800)));
         register(new LanternPotionType("minecraft", "luck", "%s.effect.luck", 36)
                 .add(PotionEffect.of(PotionEffectTypes.LUCK, 0, 6000)));
+    }
+
+    @Override
+    public ForgeRegistryData getRegistryData() {
+        return new ForgeRegistryData("minecraft:potiontypes", getRegistryDataMappings());
     }
 }

--- a/src/main/java/org/lanternpowered/server/game/registry/type/effect/sound/SoundTypeRegistryModule.java
+++ b/src/main/java/org/lanternpowered/server/game/registry/type/effect/sound/SoundTypeRegistryModule.java
@@ -27,15 +27,21 @@ package org.lanternpowered.server.game.registry.type.effect.sound;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
+import it.unimi.dsi.fastutil.objects.Object2IntMap;
+import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
+import org.lanternpowered.server.catalog.PluginCatalogType;
+import org.lanternpowered.server.catalog.VirtualCatalogType;
 import org.lanternpowered.server.effect.sound.LanternSoundType;
 import org.lanternpowered.server.game.registry.AdditionalPluginCatalogRegistryModule;
+import org.lanternpowered.server.game.registry.forge.ForgeCatalogRegistryModule;
+import org.lanternpowered.server.game.registry.forge.ForgeRegistryData;
 import org.spongepowered.api.effect.sound.SoundType;
 import org.spongepowered.api.effect.sound.SoundTypes;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
 
-public final class SoundTypeRegistryModule extends AdditionalPluginCatalogRegistryModule<SoundType> {
+public final class SoundTypeRegistryModule extends AdditionalPluginCatalogRegistryModule<SoundType> implements ForgeCatalogRegistryModule<SoundType> {
 
     public SoundTypeRegistryModule() {
         super(SoundTypes.class);
@@ -51,5 +57,17 @@ public final class SoundTypeRegistryModule extends AdditionalPluginCatalogRegist
             final String id = name.replaceAll("\\.", "_");
             register(new LanternSoundType("minecraft", id, name, i));
         }
+    }
+
+    @Override
+    public ForgeRegistryData getRegistryData() {
+        final Object2IntMap<String> map = new Object2IntOpenHashMap<>();
+        getAll().forEach(soundType -> {
+            if (!(soundType instanceof VirtualCatalogType)) {
+                // Well okey, forge still uses dots in their sound type mappings :|
+                map.put(((PluginCatalogType) soundType).getPluginId() + ':' + soundType.getName(), ((LanternSoundType) soundType).getEventId());
+            }
+        });
+        return new ForgeRegistryData("minecraft:soundevents", map);
     }
 }

--- a/src/main/java/org/lanternpowered/server/game/registry/type/item/EnchantmentTypeRegistryModule.java
+++ b/src/main/java/org/lanternpowered/server/game/registry/type/item/EnchantmentTypeRegistryModule.java
@@ -26,11 +26,14 @@
 package org.lanternpowered.server.game.registry.type.item;
 
 import org.lanternpowered.server.game.registry.InternalPluginCatalogRegistryModule;
+import org.lanternpowered.server.game.registry.forge.ForgeCatalogRegistryModule;
+import org.lanternpowered.server.game.registry.forge.ForgeRegistryData;
 import org.lanternpowered.server.item.enchantment.LanternEnchantmentType;
 import org.spongepowered.api.item.enchantment.EnchantmentType;
 import org.spongepowered.api.item.enchantment.EnchantmentTypes;
 
-public class EnchantmentTypeRegistryModule extends InternalPluginCatalogRegistryModule<EnchantmentType> {
+public class EnchantmentTypeRegistryModule extends InternalPluginCatalogRegistryModule<EnchantmentType>
+        implements ForgeCatalogRegistryModule<EnchantmentType> {
 
     private static final EnchantmentTypeRegistryModule INSTANCE = new EnchantmentTypeRegistryModule();
 
@@ -73,5 +76,10 @@ public class EnchantmentTypeRegistryModule extends InternalPluginCatalogRegistry
         register(new LanternEnchantmentType("minecraft", "lure", "enchantment.fishingSpeed", 62));
         register(new LanternEnchantmentType("minecraft", "mending", "enchantment.mending", 70));
         register(new LanternEnchantmentType("minecraft", "vanishing_curse", "enchantment.vanishing_curse", 71));
+    }
+
+    @Override
+    public ForgeRegistryData getRegistryData() {
+        return new ForgeRegistryData("minecraft:enchantments", getRegistryDataMappings());
     }
 }

--- a/src/main/java/org/lanternpowered/server/game/registry/type/item/ItemRegistryModule.java
+++ b/src/main/java/org/lanternpowered/server/game/registry/type/item/ItemRegistryModule.java
@@ -45,11 +45,14 @@ import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
+import org.lanternpowered.server.catalog.VirtualCatalogType;
 import org.lanternpowered.server.data.key.LanternKeys;
 import org.lanternpowered.server.data.type.LanternDyeColor;
 import org.lanternpowered.server.effect.potion.PotionType;
 import org.lanternpowered.server.game.Lantern;
 import org.lanternpowered.server.game.registry.AdditionalPluginCatalogRegistryModule;
+import org.lanternpowered.server.game.registry.forge.ForgeCatalogRegistryModule;
+import org.lanternpowered.server.game.registry.forge.ForgeRegistryData;
 import org.lanternpowered.server.game.registry.type.block.BlockRegistryModule;
 import org.lanternpowered.server.game.registry.type.data.ArmorTypeRegistryModule;
 import org.lanternpowered.server.game.registry.type.data.CookedFishRegistryModule;
@@ -116,7 +119,8 @@ import java.util.function.Function;
         RecordTypeRegistryModule.class,
         EquipmentTypeRegistryModule.class,
 })
-public final class ItemRegistryModule extends AdditionalPluginCatalogRegistryModule<ItemType> implements ItemRegistry {
+public final class ItemRegistryModule extends AdditionalPluginCatalogRegistryModule<ItemType> implements ItemRegistry,
+        ForgeCatalogRegistryModule<ItemType> {
 
     private static class Holder {
 
@@ -147,6 +151,24 @@ public final class ItemRegistryModule extends AdditionalPluginCatalogRegistryMod
         this.internalIdByItemType.put(itemType, internalId);
         this.itemTypeByInternalId.put(internalId, itemType);
         Lantern.getGame().getPropertyRegistry().registerItemPropertyStores(((LanternItemType) itemType).getPropertyProviderCollection());
+    }
+
+    @Override
+    public ForgeRegistryData getRegistryData() {
+        final Object2IntMap<String> map = new Object2IntOpenHashMap<>();
+        this.itemTypeByInternalId.int2ObjectEntrySet().forEach(entry -> {
+            if (!(entry.getValue() instanceof VirtualCatalogType)) {
+                map.put(entry.getValue().getId(), entry.getIntKey());
+            }
+        });
+        // The forge/vanilla client doesn't have a
+        // of a none item type like in sponge, however they
+        // use air (like the block) in this case.
+        // AIR MAY NEVER BE REMOVED, you can expect some
+        // crashes if you do so.
+        map.remove("minecraft:none");
+        map.put("minecraft:air", 0);
+        return new ForgeRegistryData("minecraft:items", map);
     }
 
     @Override

--- a/src/main/java/org/lanternpowered/server/game/registry/type/world/biome/BiomeRegistryModule.java
+++ b/src/main/java/org/lanternpowered/server/game/registry/type/world/biome/BiomeRegistryModule.java
@@ -28,11 +28,16 @@ package org.lanternpowered.server.game.registry.type.world.biome;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
+import it.unimi.dsi.fastutil.objects.Object2IntMap;
+import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import it.unimi.dsi.fastutil.objects.Object2ShortMap;
 import it.unimi.dsi.fastutil.objects.Object2ShortOpenHashMap;
 import it.unimi.dsi.fastutil.shorts.Short2ObjectMap;
 import it.unimi.dsi.fastutil.shorts.Short2ObjectOpenHashMap;
+import org.lanternpowered.server.catalog.VirtualCatalogType;
 import org.lanternpowered.server.game.registry.AdditionalPluginCatalogRegistryModule;
+import org.lanternpowered.server.game.registry.forge.ForgeCatalogRegistryModule;
+import org.lanternpowered.server.game.registry.forge.ForgeRegistryData;
 import org.lanternpowered.server.world.biome.LanternBiomeType;
 import org.spongepowered.api.world.biome.BiomeType;
 import org.spongepowered.api.world.biome.BiomeTypes;
@@ -40,7 +45,8 @@ import org.spongepowered.api.world.biome.BiomeTypes;
 import java.util.Optional;
 
 // TODO Lookup biome registry data from the worlds.
-public final class BiomeRegistryModule extends AdditionalPluginCatalogRegistryModule<BiomeType> implements BiomeRegistry {
+public final class BiomeRegistryModule extends AdditionalPluginCatalogRegistryModule<BiomeType> implements BiomeRegistry,
+        ForgeCatalogRegistryModule<BiomeType> {
 
     private static final BiomeRegistryModule INSTANCE = new BiomeRegistryModule();
 
@@ -55,6 +61,17 @@ public final class BiomeRegistryModule extends AdditionalPluginCatalogRegistryMo
 
     private BiomeRegistryModule() {
         super(BiomeTypes.class);
+    }
+
+    @Override
+    public ForgeRegistryData getRegistryData() {
+        final Object2IntMap<String> map = new Object2IntOpenHashMap<>();
+        this.biomeTypeByInternalId.short2ObjectEntrySet().forEach(entry -> {
+            if (!(entry.getValue() instanceof VirtualCatalogType)) {
+                map.put(entry.getValue().getId(), entry.getShortKey());
+            }
+        });
+        return new ForgeRegistryData("minecraft:biomes", map);
     }
 
     @Override

--- a/src/main/java/org/lanternpowered/server/network/NetworkSession.java
+++ b/src/main/java/org/lanternpowered/server/network/NetworkSession.java
@@ -382,6 +382,11 @@ public final class NetworkSession extends SimpleChannelInboundHandler<Message> i
         return this.player;
     }
 
+    @Nullable
+    public LanternPlayer getPlayerNullable() {
+        return this.player;
+    }
+
     @Override
     public int getLatency() {
         return this.latency;
@@ -792,7 +797,6 @@ public final class NetworkSession extends SimpleChannelInboundHandler<Message> i
             if (!event.isMessageCancelled()) {
                 event.getChannel().ifPresent(channel -> channel.send(this.player, event.getMessage()));
             }
-
             causeStack.popCause();
 
             // Remove the proxy user from the player and save the player data
@@ -949,6 +953,9 @@ public final class NetworkSession extends SimpleChannelInboundHandler<Message> i
         if (!joinEvent.isMessageCancelled()) {
             joinEvent.getChannel().ifPresent(channel -> channel.send(this.player, joinEvent.getMessage()));
         }
+
+        this.registeredChannels.forEach(channel -> Sponge.getEventManager()
+                .post(SpongeEventFactory.createChannelRegistrationEventRegister(cause, channel)));
 
         this.server.getDefaultResourcePack().ifPresent(this.player::sendResourcePack);
         this.player.resetIdleTimeoutCounter();

--- a/src/main/java/org/lanternpowered/server/network/buffer/objects/Types.java
+++ b/src/main/java/org/lanternpowered/server/network/buffer/objects/Types.java
@@ -225,13 +225,13 @@ public final class Types {
 
         @Override
         public RawItemStack read(ByteBuffer buf) throws CodecException {
-            short id = buf.readShort();
+            final short id = buf.readShort();
             if (id == -1) {
                 return null;
             }
-            int amount = buf.readByte();
-            int data = buf.readShort();
-            DataView dataView = buf.readDataView();
+            final int amount = buf.readByte();
+            final int data = buf.readShort();
+            final DataView dataView = buf.readDataView();
             return new RawItemStack(id, data, amount, dataView);
         }
     });

--- a/src/main/java/org/lanternpowered/server/network/forge/ForgeProtocol.java
+++ b/src/main/java/org/lanternpowered/server/network/forge/ForgeProtocol.java
@@ -23,29 +23,33 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.lanternpowered.server.network.vanilla.message.type.play;
+package org.lanternpowered.server.network.forge;
 
-import org.lanternpowered.server.network.message.Message;
-import org.spongepowered.api.item.inventory.ItemStack;
+import io.netty.util.AttributeKey;
+import org.lanternpowered.server.network.forge.handshake.ForgeServerHandshakePhase;
 
-import javax.annotation.Nullable;
+public final class ForgeProtocol {
 
-public final class MessagePlayInCreativeWindowAction implements Message {
+    /**
+     * The attribute key of the server handshake phase.
+     */
+    public static final AttributeKey<ForgeServerHandshakePhase> HANDSHAKE_PHASE = AttributeKey.valueOf("fml-handshake-phase");
 
-    private final int slot;
-    @Nullable private final ItemStack itemStack;
+    /**
+     * The name of the main channel.
+     */
+    public static final String MAIN_CHANNEL = "FML";
 
-    public MessagePlayInCreativeWindowAction(int slot, @Nullable ItemStack itemStack) {
-        this.itemStack = itemStack;
-        this.slot = slot;
-    }
+    /**
+     * The name of the forge handshake channel.
+     */
+    public static final String HANDSHAKE_CHANNEL = "FML|HS";
 
-    public int getSlot() {
-        return this.slot;
-    }
+    /**
+     * The name of the forge multi part message channel.
+     */
+    public static final String MULTI_PART_MESSAGE_CHANNEL = "FML|MP";
 
-    @Nullable
-    public ItemStack getItemStack() {
-        return this.itemStack;
+    private ForgeProtocol() {
     }
 }

--- a/src/main/java/org/lanternpowered/server/network/forge/handshake/ForgeHandshakePhase.java
+++ b/src/main/java/org/lanternpowered/server/network/forge/handshake/ForgeHandshakePhase.java
@@ -25,12 +25,5 @@
  */
 package org.lanternpowered.server.network.forge.handshake;
 
-import io.netty.util.AttributeKey;
-
 public interface ForgeHandshakePhase {
-
-    /**
-     * The attribute key of the server handshake phase.
-     */
-    AttributeKey<ForgeServerHandshakePhase> PHASE = AttributeKey.valueOf("fml-handshake-phase");
 }

--- a/src/main/java/org/lanternpowered/server/network/forge/message/codec/handshake/CodecPlayInOutCustomPayload.java
+++ b/src/main/java/org/lanternpowered/server/network/forge/message/codec/handshake/CodecPlayInOutCustomPayload.java
@@ -25,6 +25,8 @@
  */
 package org.lanternpowered.server.network.forge.message.codec.handshake;
 
+import static org.lanternpowered.server.network.forge.ForgeProtocol.HANDSHAKE_CHANNEL;
+
 import com.google.common.collect.Maps;
 import io.netty.handler.codec.CodecException;
 import io.netty.handler.codec.DecoderException;
@@ -51,36 +53,37 @@ public final class CodecPlayInOutCustomPayload extends AbstractCodecPlayInOutCus
     private static final int FML_HANDSHAKE_ACK = -1;
     private static final int FML_HANDSHAKE_RESET = -2;
 
-    // We will still use protocol 1, so we don't have to send
-    // the overridden dimension id (maybe once we add support for that)
-    // we could change it to 2 or higher future versions
-    private final static int FORGE_PROTOCOL = 1;
+    // The protocol version, the dimension field is only send when protocol >= 2
+    private final static int FORGE_PROTOCOL = 2;
+    // Don't override the dimension, a 0 is send in this case
+    private final static int FORGE_OVERRIDDEN_DIMENSION = 0;
 
     @Override
     protected MessageResult encode0(CodecContext context, Message message) throws CodecException {
         if (message instanceof MessageForgeHandshakeInOutAck) {
-            return new MessageResult("FML|HS", context.byteBufAlloc()
+            return new MessageResult(HANDSHAKE_CHANNEL, context.byteBufAlloc()
                     .buffer(2)
                     .writeByte((byte) FML_HANDSHAKE_ACK)
                     // Only the server state should be send to the client
                     .writeByte((byte) ((ForgeServerHandshakePhase) ((MessageForgeHandshakeInOutAck) message).getPhase()).ordinal()));
         } else if (message instanceof MessageForgeHandshakeInOutHello) {
-            return new MessageResult("FML|HS", context.byteBufAlloc()
-                    .buffer(2)
+            return new MessageResult(HANDSHAKE_CHANNEL, context.byteBufAlloc()
+                    .buffer(3)
                     .writeByte((byte) FML_HANDSHAKE_SERVER_HELLO)
-                    .writeByte((byte) FORGE_PROTOCOL));
+                    .writeByte((byte) FORGE_PROTOCOL)
+                    .writeInteger(FORGE_OVERRIDDEN_DIMENSION));
         } else if (message instanceof MessageForgeHandshakeInOutModList) {
-            Map<String, String> entries = ((MessageForgeHandshakeInOutModList) message).getEntries();
-            ByteBuffer buf = context.byteBufAlloc().buffer();
+            final Map<String, String> entries = ((MessageForgeHandshakeInOutModList) message).getEntries();
+            final ByteBuffer buf = context.byteBufAlloc().buffer();
             buf.writeByte((byte) FML_HANDSHAKE_MOD_LIST);
             buf.writeVarInt(entries.size());
             for (Map.Entry<String, String> en : entries.entrySet()) {
                 buf.writeString(en.getKey());
                 buf.writeString(en.getValue());
             }
-            return new MessageResult("FML|HS", buf);
+            return new MessageResult(HANDSHAKE_CHANNEL, buf);
         } else if (message instanceof MessageForgeHandshakeOutReset) {
-            return new MessageResult("FML|HS", context.byteBufAlloc()
+            return new MessageResult(HANDSHAKE_CHANNEL, context.byteBufAlloc()
                     .buffer(1).writeByte((byte) FML_HANDSHAKE_RESET));
         }
         throw new EncoderException("Unsupported message type: " + message);
@@ -88,14 +91,14 @@ public final class CodecPlayInOutCustomPayload extends AbstractCodecPlayInOutCus
 
     @Override
     protected Message decode0(CodecContext context, String channel, ByteBuffer content) throws CodecException {
-        if ("FML|HS".equals(channel)) {
+        if (HANDSHAKE_CHANNEL.equals(channel)) {
             int type = content.readByte();
             switch (type) {
                 case FML_HANDSHAKE_RESET:
                     // server -> client message: ignore
                     break;
                 case FML_HANDSHAKE_ACK:
-                    ForgeClientHandshakePhase phase = ForgeClientHandshakePhase.values()[content.readByte()];
+                    final ForgeClientHandshakePhase phase = ForgeClientHandshakePhase.values()[content.readByte()];
                     return new MessageForgeHandshakeInOutAck(phase);
                 case FML_HANDSHAKE_SERVER_HELLO:
                     // server -> client message: ignore
@@ -104,8 +107,8 @@ public final class CodecPlayInOutCustomPayload extends AbstractCodecPlayInOutCus
                     content.readByte(); // The forge protocol version on the client
                     return new MessageForgeHandshakeInOutHello();
                 case FML_HANDSHAKE_MOD_LIST:
-                    int size = content.readVarInt();
-                    Map<String, String> entries = Maps.newHashMapWithExpectedSize(size);
+                    final int size = content.readVarInt();
+                    final Map<String, String> entries = Maps.newHashMapWithExpectedSize(size);
                     for (int i = 0; i < size; i++) {
                         entries.put(content.readString(), content.readString());
                     }

--- a/src/main/java/org/lanternpowered/server/network/forge/message/codec/handshake/ProcessorForgeHandshakeOutRegistryData.java
+++ b/src/main/java/org/lanternpowered/server/network/forge/message/codec/handshake/ProcessorForgeHandshakeOutRegistryData.java
@@ -25,7 +25,10 @@
  */
 package org.lanternpowered.server.network.forge.message.codec.handshake;
 
+import static org.lanternpowered.server.network.forge.ForgeProtocol.HANDSHAKE_CHANNEL;
+
 import io.netty.handler.codec.CodecException;
+import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import org.lanternpowered.server.network.buffer.ByteBuffer;
 import org.lanternpowered.server.network.forge.message.type.handshake.MessageForgeHandshakeOutRegistryData;
 import org.lanternpowered.server.network.forge.message.type.handshake.MessageForgeHandshakeOutRegistryData.Entry;
@@ -37,6 +40,7 @@ import org.lanternpowered.server.network.vanilla.message.type.play.MessagePlayIn
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public final class ProcessorForgeHandshakeOutRegistryData implements Processor<MessageForgeHandshakeOutRegistryData> {
 
@@ -52,16 +56,22 @@ public final class ProcessorForgeHandshakeOutRegistryData implements Processor<M
             buf.writeByte((byte) CodecPlayInOutCustomPayload.FML_HANDSHAKE_REGISTRY_DATA);
             buf.writeBoolean(it.hasNext());
             buf.writeString(entry.getName());
-            final Map<String, Integer> ids = entry.getIds();
+            final Object2IntMap<String> ids = entry.getIds();
             buf.writeVarInt(ids.size());
-            for (Map.Entry<String, Integer> en : ids.entrySet()) {
+            for (Object2IntMap.Entry<String> en : ids.object2IntEntrySet()) {
                 buf.writeString(en.getKey());
-                buf.writeVarInt(en.getValue());
+                buf.writeVarInt(en.getIntValue());
             }
-            final List<String> substitutions = entry.getSubstitutions();
-            buf.writeVarInt(substitutions.size());
-            substitutions.forEach(buf::writeString);
-            output.add(new MessagePlayInOutChannelPayload("FML|HS", buf));
+            final Set<String> dummies = entry.getDummies();
+            buf.writeVarInt(dummies.size());
+            dummies.forEach(buf::writeString);
+            final Map<String, String> overrides = entry.getOverrides();
+            buf.writeVarInt(overrides.size());
+            for (Map.Entry<String, String> en : overrides.entrySet()) {
+                buf.writeString(en.getKey());
+                buf.writeString(en.getValue());
+            }
+            output.add(new MessagePlayInOutChannelPayload(HANDSHAKE_CHANNEL, buf));
         }
     }
 }

--- a/src/main/java/org/lanternpowered/server/network/forge/message/handler/handshake/HandlerForgeHandshakeInHello.java
+++ b/src/main/java/org/lanternpowered/server/network/forge/message/handler/handshake/HandlerForgeHandshakeInHello.java
@@ -30,7 +30,7 @@ import static org.lanternpowered.server.text.translation.TranslationHelper.t;
 import io.netty.util.Attribute;
 import org.lanternpowered.server.game.Lantern;
 import org.lanternpowered.server.network.NetworkContext;
-import org.lanternpowered.server.network.forge.handshake.ForgeHandshakePhase;
+import org.lanternpowered.server.network.forge.ForgeProtocol;
 import org.lanternpowered.server.network.forge.handshake.ForgeServerHandshakePhase;
 import org.lanternpowered.server.network.forge.message.type.handshake.MessageForgeHandshakeInOutHello;
 import org.lanternpowered.server.network.message.handler.Handler;
@@ -41,11 +41,11 @@ public final class HandlerForgeHandshakeInHello implements Handler<MessageForgeH
     @Override
     public void handle(NetworkContext context, MessageForgeHandshakeInOutHello message) {
         final NetworkSession session = context.getSession();
-        final Attribute<ForgeServerHandshakePhase> phase = session.getChannel().attr(ForgeHandshakePhase.PHASE);
+        final Attribute<ForgeServerHandshakePhase> phase = session.getChannel().attr(ForgeProtocol.HANDSHAKE_PHASE);
         if (phase.get() != ForgeServerHandshakePhase.HELLO) {
             session.disconnect(t("Retrieved unexpected forge handshake hello message."));
             return;
         }
-        Lantern.getLogger().info("{}: Forge handshake -> Received hello message.", session.getGameProfile().getName().get());
+        Lantern.getLogger().debug("{}: Forge handshake -> Received hello message.", session.getGameProfile().getName().get());
     }
 }

--- a/src/main/java/org/lanternpowered/server/network/forge/message/handler/handshake/HandlerForgeHandshakeInModList.java
+++ b/src/main/java/org/lanternpowered/server/network/forge/message/handler/handshake/HandlerForgeHandshakeInModList.java
@@ -31,7 +31,7 @@ import io.netty.util.Attribute;
 import org.lanternpowered.server.game.Lantern;
 import org.lanternpowered.server.network.NetworkContext;
 import org.lanternpowered.server.network.NetworkSession;
-import org.lanternpowered.server.network.forge.handshake.ForgeHandshakePhase;
+import org.lanternpowered.server.network.forge.ForgeProtocol;
 import org.lanternpowered.server.network.forge.handshake.ForgeServerHandshakePhase;
 import org.lanternpowered.server.network.forge.message.type.handshake.MessageForgeHandshakeInOutModList;
 import org.lanternpowered.server.network.message.handler.Handler;
@@ -43,7 +43,7 @@ public final class HandlerForgeHandshakeInModList implements Handler<MessageForg
     @Override
     public void handle(NetworkContext context, MessageForgeHandshakeInOutModList message) {
         final NetworkSession session = context.getSession();
-        final Attribute<ForgeServerHandshakePhase> phase = context.getChannel().attr(ForgeHandshakePhase.PHASE);
+        final Attribute<ForgeServerHandshakePhase> phase = context.getChannel().attr(ForgeProtocol.HANDSHAKE_PHASE);
         if (phase.get() != ForgeServerHandshakePhase.HELLO) {
             session.disconnect(t("Retrieved unexpected forge handshake modList message."));
             return;
@@ -53,6 +53,6 @@ public final class HandlerForgeHandshakeInModList implements Handler<MessageForg
         // Just use a empty map for now
         session.send(new MessageForgeHandshakeInOutModList(new HashMap<>()));
         phase.set(ForgeServerHandshakePhase.WAITING_ACK);
-        Lantern.getLogger().info("{}: Forge handshake -> Received modList message.", session.getGameProfile().getName().get());
+        Lantern.getLogger().debug("{}: Forge handshake -> Received modList message.", session.getGameProfile().getName().get());
     }
 }

--- a/src/main/java/org/lanternpowered/server/network/forge/message/handler/handshake/HandlerForgeHandshakeInStart.java
+++ b/src/main/java/org/lanternpowered/server/network/forge/message/handler/handshake/HandlerForgeHandshakeInStart.java
@@ -31,7 +31,7 @@ import io.netty.util.Attribute;
 import org.lanternpowered.server.game.Lantern;
 import org.lanternpowered.server.network.NetworkContext;
 import org.lanternpowered.server.network.NetworkSession;
-import org.lanternpowered.server.network.forge.handshake.ForgeHandshakePhase;
+import org.lanternpowered.server.network.forge.ForgeProtocol;
 import org.lanternpowered.server.network.forge.handshake.ForgeServerHandshakePhase;
 import org.lanternpowered.server.network.forge.message.type.handshake.MessageForgeHandshakeInOutHello;
 import org.lanternpowered.server.network.forge.message.type.handshake.MessageForgeHandshakeInStart;
@@ -48,7 +48,7 @@ public final class HandlerForgeHandshakeInStart implements Handler<MessageForgeH
 
     @Override
     public void handle(NetworkContext context, MessageForgeHandshakeInStart message) {
-        final Attribute<ForgeServerHandshakePhase> phase = context.getChannel().attr(ForgeHandshakePhase.PHASE);
+        final Attribute<ForgeServerHandshakePhase> phase = context.getChannel().attr(ForgeProtocol.HANDSHAKE_PHASE);
         final NetworkSession session = context.getSession();
         if (phase.get() != null && phase.get() != ForgeServerHandshakePhase.START) {
             session.disconnect(t("Retrieved unexpected forge handshake start message."));
@@ -59,9 +59,9 @@ public final class HandlerForgeHandshakeInStart implements Handler<MessageForgeH
         final Set<String> channels = new HashSet<>(Sponge.getChannelRegistrar()
                 .getRegisteredChannels(Platform.Type.SERVER));
         if (fml) {
-            channels.add("FML");
-            channels.add("FML|HS");
-            channels.add("FML|MP");
+            channels.add(ForgeProtocol.MAIN_CHANNEL);
+            channels.add(ForgeProtocol.HANDSHAKE_CHANNEL);
+            channels.add(ForgeProtocol.MULTI_PART_MESSAGE_CHANNEL);
         }
         if (!channels.isEmpty()) {
             session.send(new MessagePlayInOutRegisterChannels(channels));
@@ -69,12 +69,12 @@ public final class HandlerForgeHandshakeInStart implements Handler<MessageForgeH
         // Disable Forge for now, we need to send the registries and stuff,
         // which isn't actually used. We may also remove the protocol in the
         // future if sponge uses completely it's own protocol.
-        if (false && fml) {
+        if (Lantern.getGame().getGlobalConfig().getForge().isEnabled() && fml) {
             phase.set(ForgeServerHandshakePhase.HELLO);
             session.send(new MessageForgeHandshakeInOutHello());
-            Lantern.getLogger().info("{}: Start forge handshake.", session.getGameProfile().getName().get());
+            Lantern.getLogger().debug("{}: Start forge handshake.", session.getGameProfile().getName().get());
         } else {
-            Lantern.getLogger().info("{}: Skip forge handshake.", session.getGameProfile().getName().get());
+            Lantern.getLogger().debug("{}: Skip forge handshake.", session.getGameProfile().getName().get());
             phase.set(ForgeServerHandshakePhase.DONE);
             session.setProtocolState(ProtocolState.PLAY);
             session.initPlayer();

--- a/src/main/java/org/lanternpowered/server/network/forge/message/type/handshake/MessageForgeHandshakeOutRegistryData.java
+++ b/src/main/java/org/lanternpowered/server/network/forge/message/type/handshake/MessageForgeHandshakeOutRegistryData.java
@@ -26,10 +26,12 @@
 package org.lanternpowered.server.network.forge.message.type.handshake;
 
 import com.google.common.collect.ImmutableList;
+import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import org.lanternpowered.server.network.message.Message;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public final class MessageForgeHandshakeOutRegistryData implements Message {
 
@@ -46,11 +48,13 @@ public final class MessageForgeHandshakeOutRegistryData implements Message {
     public static class Entry {
 
         private final String name;
-        private final Map<String, Integer> ids;
-        private final List<String> substitutions;
+        private final Object2IntMap<String> ids;
+        private final Map<String, String> overrides;
+        private final Set<String> dummies;
 
-        public Entry(String name, Map<String, Integer> ids, List<String> substitutions) {
-            this.substitutions = substitutions;
+        public Entry(String name, Object2IntMap<String> ids, Map<String, String> overrides, Set<String> dummies) {
+            this.overrides = overrides;
+            this.dummies = dummies;
             this.name = name;
             this.ids = ids;
         }
@@ -59,12 +63,16 @@ public final class MessageForgeHandshakeOutRegistryData implements Message {
             return this.name;
         }
 
-        public Map<String, Integer> getIds() {
+        public Object2IntMap<String> getIds() {
             return this.ids;
         }
 
-        public List<String> getSubstitutions() {
-            return this.substitutions;
+        public Map<String, String> getOverrides() {
+            return this.overrides;
+        }
+
+        public Set<String> getDummies() {
+            return this.dummies;
         }
     }
 }

--- a/src/main/java/org/lanternpowered/server/network/vanilla/message/handler/login/HandlerEncryptionResponse.java
+++ b/src/main/java/org/lanternpowered/server/network/vanilla/message/handler/login/HandlerEncryptionResponse.java
@@ -234,7 +234,7 @@ public final class HandlerEncryptionResponse implements Handler<MessageLoginInEn
                     .createPropertiesMapFromJson(json.getAsJsonArray("properties"));
             final LanternGameProfile gameProfile = new LanternGameProfile(uuid, name, properties);
 
-            Lantern.getLogger().info("Finished authenticating.");
+            Lantern.getLogger().debug("Finished authenticating.");
 
             final Cause cause = Cause.of(EventContext.empty(), session, gameProfile);
             final ClientConnectionEvent.Auth event = SpongeEventFactory.createClientConnectionEventAuth(cause,

--- a/src/main/java/org/lanternpowered/server/world/biome/LanternVirtualBiomeType.java
+++ b/src/main/java/org/lanternpowered/server/world/biome/LanternVirtualBiomeType.java
@@ -28,6 +28,7 @@ package org.lanternpowered.server.world.biome;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.base.MoreObjects;
+import org.lanternpowered.server.catalog.VirtualCatalogType;
 import org.spongepowered.api.world.World;
 import org.spongepowered.api.world.biome.BiomeGenerationSettings;
 import org.spongepowered.api.world.biome.BiomeType;
@@ -35,7 +36,7 @@ import org.spongepowered.api.world.biome.VirtualBiomeType;
 
 import java.util.function.Function;
 
-public class LanternVirtualBiomeType extends AbstractBiomeType implements VirtualBiomeType {
+public class LanternVirtualBiomeType extends AbstractBiomeType implements VirtualBiomeType, VirtualCatalogType {
 
     private final Function<World, BiomeGenerationSettings> settingsFunction;
     private final BiomeType persistedType;


### PR DESCRIPTION
This PR updates the Forge protocol since it's currently broken. It also sends now registry data to the forge client (this hides blocks/items in creative that are not available on the server).
Some other small issues regarding item type registration for blocks that are not supported are also being fixed, they popped up testing the protocol changes.